### PR TITLE
Performance profiling

### DIFF
--- a/stdlib/assoc.mc
+++ b/stdlib/assoc.mc
@@ -23,9 +23,11 @@ let assocLength : AssocMap k v -> Int =
 -- overwritten.
 let assocInsert : AssocTraits k -> k -> v -> AssocMap k v -> AssocMap k v =
   lam traits. lam k. lam v. lam m.
-    optionMapOrElse (lam _. cons (k,v) m)
-                    (lam i. set m i (k,v))
-                    (index (lam t. traits.eq k t.0) m)
+    -- PERFORMANCE
+    -- optionMapOrElse (lam _. cons (k,v) m)
+    --                 (lam i. set m i (k,v))
+    --                 (index (lam t. traits.eq k t.0) m)
+    cons (k,v) m
 
 -- 'seq2assoc traits ls' constructs a new association map from a sequence
 -- of tuples 'ls'. Bindings to the right overwrites previous equal bindings to

--- a/stdlib/mexpr/pprint.mc
+++ b/stdlib/mexpr/pprint.mc
@@ -67,25 +67,29 @@ let pprintEnvAdd : Name -> String -> Int -> PprintEnv -> PprintEnv =
 -- environment.
 let pprintEnvGetStr : PprintEnv -> Name -> (PprintEnv, String) =
   lam env. lam name.
-    match pprintEnvLookup name env with Some str then (env,str)
-    else
-      let baseStr = nameGetStr name in
-      if pprintEnvFree baseStr env then (pprintEnvAdd name baseStr 1 env, baseStr)
-      else
-        match env with {count = count} then
-          let start =
-            match assocLookup {eq = eqString} baseStr count
-            with Some i then i else 1 in
-          recursive let findFree : String -> Int -> (String, Int) =
-            lam baseStr. lam i.
-              let proposal = concat baseStr (int2string i) in
-              if pprintEnvFree proposal env then (proposal, i)
-              else findFree baseStr (addi i 1)
-          in
-          match findFree baseStr start with (str, i) then
-            (pprintEnvAdd name str (addi i 1) env, str)
-          else never
-        else never
+    -- PERFORMANCE
+
+    -- match pprintEnvLookup name env with Some str then (env,str)
+    -- else
+    --   let baseStr = nameGetStr name in
+    --   if pprintEnvFree baseStr env then (pprintEnvAdd name baseStr 1 env, baseStr)
+    --   else
+    --     match env with {count = count} then
+    --       let start =
+    --         match assocLookup {eq = eqString} baseStr count
+    --         with Some i then i else 1 in
+    --       recursive let findFree : String -> Int -> (String, Int) =
+    --         lam baseStr. lam i.
+    --           let proposal = concat baseStr (int2string i) in
+    --           if pprintEnvFree proposal env then (proposal, i)
+    --           else findFree baseStr (addi i 1)
+    --       in
+    --       match findFree baseStr start with (str, i) then
+    --         (pprintEnvAdd name str (addi i 1) env, str)
+    --       else never
+    --     else never
+
+    (env, nameGetStr name)
 
 -- Adds the given name to the environment, if its exact string is not already
 -- mapped to. If the exact string is already mapped to, return None (). This


### PR DESCRIPTION
Adds annotations to profile the performance of the OCaml tests. Two experimental changes to speed up the code have been done (in `pprint.mc` and in `assoc.mc`), grep the code for `PERFORMANCE` to find these places.

Example of how to do the profiling:

```
> time mi test stdlib/ocaml/generate.mc
...
-- objWrapGenerate: 5.300097e-2 s
-- MExpr eval: 5.786132e-5 s
-- expr2str: 1.498520e+0 s
-- ocamlEval: 8.999790e-1 s
-- eqExpr: 3.979492e-5 s
-- sameSemantics: 2.400305e+0 s
. OK
Unit testing SUCCESSFUL after executing 8 tests.

mi test stdlib/ocaml/generate.mc  3.42s user 0.33s system 91% cpu 4.088 total
```